### PR TITLE
Correct env creation command in environment.yaml

### DIFF
--- a/{{cookiecutter.repo_name}}/environment.yaml
+++ b/{{cookiecutter.repo_name}}/environment.yaml
@@ -1,7 +1,7 @@
 # in this yaml you should add dependencies that are not included in the python packages
 # (or that you want to install anyways such as torch to install cuda w/ conda)
 # also make sure to install the local packages with the "-e" prefix
-# to create an environment: conda create env -f environment.yaml
+# to create an environment: conda env create -f environment.yaml
 # to update: conda env update -f environment.yaml
 name: {{cookiecutter.repo_name}}
 channels:


### PR DESCRIPTION
`conda create env` command is wrong, it should be `conda env create` (maybe verify on your system with `conda create env` vs `conda env create`. I am on conda 23.1.0.